### PR TITLE
Custom input handling support

### DIFF
--- a/src/Entities/IElapsed.cs
+++ b/src/Entities/IElapsed.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Fergun.Interactive
+{
+    /// <summary>
+    /// Provides an elapsed time.
+    /// </summary>
+    public interface IElapsed
+    {
+        /// <summary>
+        /// Gets the elapsed time.
+        /// </summary>
+        TimeSpan Elapsed { get; }
+    }
+}

--- a/src/Entities/IInteractiveElement.cs
+++ b/src/Entities/IInteractiveElement.cs
@@ -7,7 +7,7 @@ namespace Fergun.Interactive
     /// Represents an interactive element.
     /// </summary>
     /// <typeparam name="TOption">The type of the options.</typeparam>
-    public interface IInteractiveElement<out TOption>
+    public interface IInteractiveElement<out TOption> : IInteractiveInputHandler
     {
         /// <summary>
         /// Gets a read-only collection of users who can interact with this element.

--- a/src/Entities/IInteractiveInputHandler.cs
+++ b/src/Entities/IInteractiveInputHandler.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using Discord;
+
+namespace Fergun.Interactive
+{
+    /// <summary>
+    /// Provides methods for handling inputs in interactive entities.
+    /// </summary>
+    public interface IInteractiveInputHandler
+    {
+        /// <summary>
+        /// Handles a message.
+        /// </summary>
+        /// <param name="input">The message to handle.</param>
+        /// <param name="message">The message containing the interactive element.</param>
+        /// <returns>A <see cref="Task{TResult}"/> containing the result.</returns>
+        Task<IInteractiveResult<InteractiveInputStatus>> HandleMessageAsync(IMessage input, IUserMessage message);
+
+        /// <summary>
+        /// Handles a reaction.
+        /// </summary>
+        /// <param name="input">The reaction to handle.</param>
+        /// <param name="message">The message containing the interactive element.</param>
+        /// <returns>A <see cref="Task{TResult}"/> containing the result.</returns>
+        Task<IInteractiveResult<InteractiveInputStatus>> HandleReactionAsync(IReaction input, IUserMessage message);
+
+        /// <summary>
+        /// Handles an interaction.
+        /// </summary>
+        /// <param name="input">The interaction to handle.</param>
+        /// <param name="message">The message containing the interactive element.</param>
+        /// <returns>A <see cref="Task{TResult}"/> containing the result.</returns>
+        Task<IInteractiveResult<InteractiveInputStatus>> HandleInteractionAsync(IDiscordInteraction input, IUserMessage message);
+    }
+}

--- a/src/Entities/IInteractiveMessageResult.cs
+++ b/src/Entities/IInteractiveMessageResult.cs
@@ -5,7 +5,7 @@ namespace Fergun.Interactive
     /// <summary>
     /// Represents a result from an interactive action containing a message associated with the action.
     /// </summary>
-    public interface IInteractiveMessageResult : IInteractiveResult
+    public interface IInteractiveMessageResult : IInteractiveResult<InteractiveStatus>, IElapsed
     {
         /// <summary>
         /// Gets the message this interactive result comes from.

--- a/src/Entities/IInteractiveResult.cs
+++ b/src/Entities/IInteractiveResult.cs
@@ -5,16 +5,12 @@ namespace Fergun.Interactive
     /// <summary>
     /// Represents a result from an interactive action.
     /// </summary>
-    public interface IInteractiveResult
+    /// <typeparam name="TStatus">The type of the status.</typeparam>
+    public interface IInteractiveResult<out TStatus> where TStatus : Enum
     {
-        /// <summary>
-        /// Gets the time passed between starting the interactive action and getting its result.
-        /// </summary>
-        public TimeSpan Elapsed { get; }
-
         /// <summary>
         /// Gets the status of this result.
         /// </summary>
-        public InteractiveStatus Status { get; }
+        TStatus Status { get; }
     }
 }

--- a/src/Entities/InteractiveInputResult.cs
+++ b/src/Entities/InteractiveInputResult.cs
@@ -1,0 +1,64 @@
+namespace Fergun.Interactive
+{
+    /// <summary>
+    /// Represents the result of an input handler in an interactive element.
+    /// </summary>
+    public class InteractiveInputResult : IInteractiveResult<InteractiveInputStatus>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractiveInputResult"/> structure with the specified action.
+        /// </summary>
+        /// <param name="status">The action.</param>
+        public InteractiveInputResult(InteractiveInputStatus status)
+        {
+            Status = status;
+        }
+
+        /// <inheritdoc/>
+        public InteractiveInputStatus Status { get; }
+
+        /// <summary>
+        /// Defines an implicit conversion of an <see cref="InteractiveInputStatus"/> to an <see cref="InteractiveInputResult"/>.
+        /// </summary>
+        /// <param name="status">The status.</param>
+        /// <returns>An <see cref="InteractiveInputResult"/>.</returns>
+        public static implicit operator InteractiveInputResult(InteractiveInputStatus status) => new(status);
+    }
+
+    /// <summary>
+    /// Represents the result of an input handler in an interactive element, with a selected option.
+    /// </summary>
+    /// <typeparam name="TOption">The type of the selected option.</typeparam>
+    public class InteractiveInputResult<TOption> : InteractiveInputResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractiveInputResult{TOption}"/> structure with the specified action.
+        /// </summary>
+        /// <param name="status">The action.</param>
+        public InteractiveInputResult(InteractiveInputStatus status) : base(status)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InteractiveInputResult{TOption}"/> structure with the specified action and selected option.
+        /// </summary>
+        /// <param name="status">The action.</param>
+        /// <param name="selectedOption">The selected option.</param>
+        public InteractiveInputResult(InteractiveInputStatus status, TOption? selectedOption) : this(status)
+        {
+            SelectedOption = selectedOption;
+        }
+
+        /// <summary>
+        /// Gets the selected option, or <see langword="default" /> if there is none.
+        /// </summary>
+        public TOption? SelectedOption { get; }
+
+        /// <summary>
+        /// Defines an implicit conversion of an <see cref="InteractiveInputStatus"/> to an <see cref="InteractiveInputResult{TOption}"/>.
+        /// </summary>
+        /// <param name="status">The status.</param>
+        /// <returns>An <see cref="InteractiveInputResult{TOption}"/>.</returns>
+        public static implicit operator InteractiveInputResult<TOption>(InteractiveInputStatus status) => new(status);
+    }
+}

--- a/src/Entities/InteractiveResult.cs
+++ b/src/Entities/InteractiveResult.cs
@@ -31,7 +31,7 @@ namespace Fergun.Interactive
     /// <summary>
     /// Represents a non-generic result from an interactive action.
     /// </summary>
-    public class InteractiveResult : IInteractiveResult
+    public class InteractiveResult : IInteractiveResult<InteractiveStatus>, IElapsed
     {
         internal InteractiveResult(TimeSpan elapsed, InteractiveStatus status = InteractiveStatus.Success)
         {

--- a/src/InteractiveExtensions.cs
+++ b/src/InteractiveExtensions.cs
@@ -37,6 +37,15 @@ namespace Fergun.Interactive
                 _ => throw new ArgumentException("Unknown interactive element.", nameof(element))
             };
 
+        public static async ValueTask<bool> CurrentUserHasManageMessagesAsync(this IMessageChannel channel)
+        {
+            if (channel is not ITextChannel textChannel)
+                return false;
+
+            var currentUser = await textChannel.Guild.GetCurrentUserAsync(CacheMode.CacheOnly);
+            return currentUser?.GetPermissions(textChannel).ManageMessages == true;
+        }
+
         public static TimeSpan GetElapsedTime(this PaginatorCallback callback, InteractiveStatus status)
             => status.GetElapsedTime(callback.StartTime, callback.TimeoutTaskSource.Delay);
 

--- a/src/InteractiveGuards.cs
+++ b/src/InteractiveGuards.cs
@@ -15,6 +15,16 @@ namespace Fergun.Interactive
             }
         }
 
+        public static void ExpectedType<TInput, TExpected>(TInput obj, string parameterName, out TExpected expected)
+        {
+            if (obj is not TExpected temp)
+            {
+                throw new ArgumentException($"Parameter must be of type {typeof(TExpected)}.", parameterName);
+            }
+
+            expected = temp;
+        }
+
         public static void MessageFromCurrentUser(BaseSocketClient client, IUserMessage? message, string parameterName)
         {
             if (message is not null && message.Author.Id != client.CurrentUser.Id)

--- a/src/InteractiveInputStatus.cs
+++ b/src/InteractiveInputStatus.cs
@@ -1,0 +1,22 @@
+namespace Fergun.Interactive
+{
+    /// <summary>
+    /// Specifies the possible status of an <see cref="IInteractiveResult{TStatus}"/> whose status is <see cref="InteractiveInputStatus"/>.
+    /// </summary>
+    /// <remarks>This is used as the status of the result of input handlers in entities that implement <see cref="IInteractiveInputHandler"/>.</remarks>
+    public enum InteractiveInputStatus
+    {
+        /// <summary>
+        /// The handling of the input was successful.
+        /// </summary>
+        Success,
+        /// <summary>
+        /// The input was ignored.
+        /// </summary>
+        Ignored,
+        /// <summary>
+        /// The handling of the input was canceled, or it was successful and the interactive entity should be canceled.
+        /// </summary>
+        Canceled
+    }
+}

--- a/src/InteractiveStatus.cs
+++ b/src/InteractiveStatus.cs
@@ -1,7 +1,7 @@
 namespace Fergun.Interactive
 {
     /// <summary>
-    /// Specifies the possible status of an <see cref="IInteractiveResult"/>.
+    /// Specifies the possible status of an <see cref="IInteractiveResult{TStatus}"/> whose status is <see cref="InteractiveStatus"/>.
     /// </summary>
     public enum InteractiveStatus
     {

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -211,6 +211,9 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc cref="IInteractiveInputHandler.HandleReactionAsync"/>
         public virtual async Task<InteractiveInputResult> HandleReactionAsync(SocketReaction input, IUserMessage message)
         {
+            InteractiveGuards.NotNull(input, nameof(input));
+            InteractiveGuards.NotNull(message, nameof(message));
+
             if (!InputType.HasFlag(InputType.Reactions) || input.MessageId != message.Id)
             {
                 return InteractiveInputStatus.Ignored;
@@ -219,12 +222,17 @@ namespace Fergun.Interactive.Pagination
             bool valid = Emotes.TryGetValue(input.Emote, out var action)
                          && this.CanInteract(input.UserId);
 
-            switch (valid)
+            bool manageMessages = await message.Channel.CurrentUserHasManageMessagesAsync().ConfigureAwait(false);
+
+            if (manageMessages)
             {
-                case false when Deletion.HasFlag(DeletionOptions.Invalid):
-                case true when Deletion.HasFlag(DeletionOptions.Valid):
-                    await message.RemoveReactionAsync(input.Emote, input.UserId).ConfigureAwait(false);
-                    break;
+                switch (valid)
+                {
+                    case false when Deletion.HasFlag(DeletionOptions.Invalid):
+                    case true when Deletion.HasFlag(DeletionOptions.Valid):
+                        await message.RemoveReactionAsync(input.Emote, input.UserId).ConfigureAwait(false);
+                        break;
+                }
             }
 
             if (!valid)
@@ -254,6 +262,9 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc cref="IInteractiveInputHandler.HandleInteractionAsync"/>
         public virtual async Task<InteractiveInputResult> HandleInteractionAsync(SocketInteraction input, IUserMessage message)
         {
+            InteractiveGuards.NotNull(input, nameof(input));
+            InteractiveGuards.NotNull(message, nameof(message));
+
             if (!InputType.HasFlag(InputType.Buttons) || input is not SocketMessageComponent interaction)
             {
                 return new(InteractiveInputStatus.Ignored);

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
+using Discord.WebSocket;
 
 namespace Fergun.Interactive.Pagination
 {
@@ -199,6 +201,120 @@ namespace Fergun.Interactive.Pagination
             }
 
             return builder.Build();
+        }
+
+        /// <inheritdoc cref="IInteractiveInputHandler.HandleMessageAsync(IMessage, IUserMessage)"/>
+        /// <remarks>If this method is not overriden, it will throw a <see cref="NotSupportedException"/> since paginators don't support message input by default.</remarks>
+        public virtual Task<InteractiveInputResult> HandleMessageAsync(IMessage input, IUserMessage message)
+            => throw new NotSupportedException("Cannot handle a message input.");
+
+        /// <inheritdoc cref="IInteractiveInputHandler.HandleReactionAsync"/>
+        public virtual async Task<InteractiveInputResult> HandleReactionAsync(SocketReaction input, IUserMessage message)
+        {
+            if (!InputType.HasFlag(InputType.Reactions) || input.MessageId != message.Id)
+            {
+                return InteractiveInputStatus.Ignored;
+            }
+
+            bool valid = Emotes.TryGetValue(input.Emote, out var action)
+                         && this.CanInteract(input.UserId);
+
+            switch (valid)
+            {
+                case false when Deletion.HasFlag(DeletionOptions.Invalid):
+                case true when Deletion.HasFlag(DeletionOptions.Valid):
+                    await message.RemoveReactionAsync(input.Emote, input.UserId).ConfigureAwait(false);
+                    break;
+            }
+
+            if (!valid)
+            {
+                return InteractiveInputStatus.Ignored;
+            }
+
+            if (action == PaginatorAction.Exit)
+            {
+                return InteractiveInputStatus.Canceled;
+            }
+
+            bool refreshPage = await ApplyActionAsync(action).ConfigureAwait(false);
+            if (refreshPage)
+            {
+                var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+                await message.ModifyAsync(x =>
+                {
+                    x.Embed = currentPage.Embed;
+                    x.Content = currentPage.Text;
+                }).ConfigureAwait(false);
+            }
+
+            return InteractiveInputStatus.Success;
+        }
+
+        /// <inheritdoc cref="IInteractiveInputHandler.HandleInteractionAsync"/>
+        public virtual async Task<InteractiveInputResult> HandleInteractionAsync(SocketInteraction input, IUserMessage message)
+        {
+            if (!InputType.HasFlag(InputType.Buttons) || input is not SocketMessageComponent interaction)
+            {
+                return new(InteractiveInputStatus.Ignored);
+            }
+
+            if (interaction.Message.Id != message.Id || !this.CanInteract(interaction.User))
+            {
+                return new(InteractiveInputStatus.Ignored);
+            }
+
+            var emote = (interaction
+                    .Message
+                    .Components
+                    .FirstOrDefault()?
+                    .Components?
+                    .FirstOrDefault(x => x is ButtonComponent button && button.CustomId == interaction.Data.CustomId) as ButtonComponent)?
+                .Emote;
+
+            if (emote is null || !Emotes.TryGetValue(emote, out var action))
+            {
+                return InteractiveInputStatus.Ignored;
+            }
+
+            if (action == PaginatorAction.Exit)
+            {
+                return InteractiveInputStatus.Canceled;
+            }
+
+            bool refreshPage = await ApplyActionAsync(action).ConfigureAwait(false);
+            if (refreshPage)
+            {
+                var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+                var buttons = BuildComponents(false);
+
+                await interaction.UpdateAsync(x =>
+                {
+                    x.Content = currentPage.Text ?? ""; // workaround for d.net bug
+                    x.Embed = currentPage.Embed;
+                    x.Components = buttons;
+                }).ConfigureAwait(false);
+            }
+
+            return InteractiveInputStatus.Success;
+        }
+
+        /// <inheritdoc />
+        async Task<IInteractiveResult<InteractiveInputStatus>> IInteractiveInputHandler.HandleMessageAsync(IMessage input, IUserMessage message)
+            => await HandleMessageAsync(input, message).ConfigureAwait(false);
+
+        /// <inheritdoc />
+        async Task<IInteractiveResult<InteractiveInputStatus>> IInteractiveInputHandler.HandleReactionAsync(IReaction input, IUserMessage message)
+        {
+            InteractiveGuards.ExpectedType<IReaction, SocketReaction>(input, nameof(input), out var socketReaction);
+            return await HandleReactionAsync(socketReaction, message).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        async Task<IInteractiveResult<InteractiveInputStatus>> IInteractiveInputHandler.HandleInteractionAsync(IDiscordInteraction input, IUserMessage message)
+        {
+            InteractiveGuards.ExpectedType<IDiscordInteraction, SocketInteraction>(input, nameof(input), out var socketInteraction);
+            return await HandleInteractionAsync(socketInteraction, message).ConfigureAwait(false);
         }
     }
 }

--- a/src/Pagination/PaginatorCallback.cs
+++ b/src/Pagination/PaginatorCallback.cs
@@ -58,7 +58,7 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketMessage message)
         {
-            var result = await Paginator.HandleMessageAsync(message, Message);
+            var result = await Paginator.HandleMessageAsync(message, Message).ConfigureAwait(false);
             switch (result.Status)
             {
                 case InteractiveInputStatus.Success:
@@ -78,7 +78,7 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketReaction reaction)
         {
-            var result = await Paginator.HandleReactionAsync(reaction, Message);
+            var result = await Paginator.HandleReactionAsync(reaction, Message).ConfigureAwait(false);
             switch (result.Status)
             {
                 case InteractiveInputStatus.Success:
@@ -98,7 +98,7 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketInteraction interaction)
         {
-            var result = await Paginator.HandleInteractionAsync(interaction, Message);
+            var result = await Paginator.HandleInteractionAsync(interaction, Message).ConfigureAwait(false);
             switch (result.Status)
             {
                 case InteractiveInputStatus.Success:

--- a/src/Pagination/PaginatorCallback.cs
+++ b/src/Pagination/PaginatorCallback.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
@@ -57,111 +56,64 @@ namespace Fergun.Interactive.Pagination
         public void Cancel() => TimeoutTaskSource.TryCancel();
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(SocketMessage message)
-            => throw new NotSupportedException("Cannot execute this callback using a message.");
+        public async Task ExecuteAsync(SocketMessage message)
+        {
+            var result = await Paginator.HandleMessageAsync(message, Message);
+            switch (result.Status)
+            {
+                case InteractiveInputStatus.Success:
+                    TimeoutTaskSource.TryReset();
+                    break;
+
+                case InteractiveInputStatus.Canceled:
+                    Cancel();
+                    break;
+
+                case InteractiveInputStatus.Ignored:
+                default:
+                    break;
+            }
+        }
 
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketReaction reaction)
         {
-            if (!Paginator.InputType.HasFlag(InputType.Reactions) || reaction.MessageId != Message.Id)
+            var result = await Paginator.HandleReactionAsync(reaction, Message);
+            switch (result.Status)
             {
-                return;
-            }
+                case InteractiveInputStatus.Success:
+                    TimeoutTaskSource.TryReset();
+                    break;
 
-            bool valid = Paginator.Emotes.TryGetValue(reaction.Emote, out var action)
-                         && Paginator.CanInteract(reaction.UserId);
+                case InteractiveInputStatus.Canceled:
+                    Cancel();
+                    break;
 
-            bool manageMessages = Message.Channel is SocketGuildChannel guildChannel
-                                  && guildChannel.Guild.CurrentUser.GetPermissions(guildChannel).ManageMessages;
-
-            if (manageMessages)
-            {
-                switch (valid)
-                {
-                    case false when Paginator.Deletion.HasFlag(DeletionOptions.Invalid):
-                    case true when Paginator.Deletion.HasFlag(DeletionOptions.Valid):
-                        await Message.RemoveReactionAsync(reaction.Emote, reaction.UserId).ConfigureAwait(false);
-                        break;
-                }
-            }
-
-            if (!valid)
-            {
-                return;
-            }
-
-            if (action == PaginatorAction.Exit)
-            {
-                Cancel();
-                return;
-            }
-
-            TimeoutTaskSource.TryReset();
-            bool refreshPage = await Paginator.ApplyActionAsync(action).ConfigureAwait(false);
-            if (refreshPage)
-            {
-                var currentPage = await Paginator.GetOrLoadCurrentPageAsync().ConfigureAwait(false);
-                await Message.ModifyAsync(x =>
-                {
-                    x.Embed = currentPage.Embed;
-                    x.Content = currentPage.Text;
-                }).ConfigureAwait(false);
+                case InteractiveInputStatus.Ignored:
+                default:
+                    break;
             }
         }
 
         /// <inheritdoc/>
-        public Task ExecuteAsync(SocketInteraction interaction)
+        public async Task ExecuteAsync(SocketInteraction interaction)
         {
-            if (Paginator.InputType.HasFlag(InputType.Buttons) && interaction is SocketMessageComponent componentInteraction)
+            var result = await Paginator.HandleInteractionAsync(interaction, Message);
+            switch (result.Status)
             {
-                return ExecuteAsync(componentInteraction);
-            }
+                case InteractiveInputStatus.Success:
+                    LastInteraction = interaction;
+                    TimeoutTaskSource.TryReset();
+                    break;
 
-            return Task.CompletedTask;
-        }
+                case InteractiveInputStatus.Canceled:
+                    StopInteraction = interaction as SocketMessageComponent ?? StopInteraction;
+                    Cancel();
+                    break;
 
-        public async Task ExecuteAsync(SocketMessageComponent interaction)
-        {
-            if (interaction.Message.Id != Message.Id || !Paginator.CanInteract(interaction.User))
-            {
-                return;
-            }
-
-            var emote = (interaction
-                .Message
-                .Components
-                .FirstOrDefault()?
-                .Components?
-                .FirstOrDefault(x => x is ButtonComponent button && button.CustomId == interaction.Data.CustomId) as ButtonComponent)?
-                .Emote;
-
-            if (emote is null || !Paginator.Emotes.TryGetValue(emote, out var action))
-            {
-                return;
-            }
-
-            if (action == PaginatorAction.Exit)
-            {
-                StopInteraction = interaction;
-                Cancel();
-                return;
-            }
-
-            LastInteraction = interaction;
-
-            TimeoutTaskSource.TryReset();
-            bool refreshPage = await Paginator.ApplyActionAsync(action).ConfigureAwait(false);
-            if (refreshPage)
-            {
-                var currentPage = await Paginator.GetOrLoadCurrentPageAsync().ConfigureAwait(false);
-                var buttons = Paginator.BuildComponents(false);
-
-                await interaction.UpdateAsync(x =>
-                {
-                    x.Content = currentPage.Text ?? ""; // workaround for d.net bug
-                    x.Embed = currentPage.Embed;
-                    x.Components = buttons;
-                }).ConfigureAwait(false);
+                case InteractiveInputStatus.Ignored:
+                default:
+                    break;
             }
         }
 

--- a/src/Selection/BaseSelection.cs
+++ b/src/Selection/BaseSelection.cs
@@ -242,10 +242,15 @@ namespace Fergun.Interactive.Selection
         /// <inheritdoc cref="IInteractiveInputHandler.HandleMessageAsync"/>
         public virtual async Task<InteractiveInputResult<TOption>> HandleMessageAsync(IMessage input, IUserMessage message)
         {
+            InteractiveGuards.NotNull(input, nameof(input));
+            InteractiveGuards.NotNull(message, nameof(message));
+
             if (!InputType.HasFlag(InputType.Messages) || !this.CanInteract(input.Author))
             {
                 return InteractiveInputStatus.Ignored;
             }
+
+            bool manageMessages = await message.Channel.CurrentUserHasManageMessagesAsync().ConfigureAwait(false);
 
             TOption? selected = default;
             string? selectedString = null;
@@ -260,7 +265,7 @@ namespace Fergun.Interactive.Selection
 
             if (selectedString is null)
             {
-                if (Deletion.HasFlag(DeletionOptions.Invalid))
+                if (manageMessages && Deletion.HasFlag(DeletionOptions.Invalid))
                 {
                     await input.DeleteAsync().ConfigureAwait(false);
                 }
@@ -274,7 +279,7 @@ namespace Fergun.Interactive.Selection
                 return new(InteractiveInputStatus.Canceled, selected!);
             }
 
-            if (Deletion.HasFlag(DeletionOptions.Valid))
+            if (manageMessages && Deletion.HasFlag(DeletionOptions.Valid))
             {
                 await input.DeleteAsync().ConfigureAwait(false);
             }
@@ -285,10 +290,15 @@ namespace Fergun.Interactive.Selection
         /// <inheritdoc cref="IInteractiveInputHandler.HandleReactionAsync"/>
         public virtual async Task<InteractiveInputResult<TOption>> HandleReactionAsync(SocketReaction input, IUserMessage message)
         {
+            InteractiveGuards.NotNull(input, nameof(input));
+            InteractiveGuards.NotNull(message, nameof(message));
+
             if (!InputType.HasFlag(InputType.Reactions) || !this.CanInteract(input.UserId))
             {
                 return InteractiveInputStatus.Ignored;
             }
+
+            bool manageMessages = await message.Channel.CurrentUserHasManageMessagesAsync().ConfigureAwait(false);
 
             TOption? selected = default;
             IEmote? selectedEmote = null;
@@ -303,7 +313,7 @@ namespace Fergun.Interactive.Selection
 
             if (selectedEmote is null)
             {
-                if (Deletion.HasFlag(DeletionOptions.Invalid))
+                if (manageMessages && Deletion.HasFlag(DeletionOptions.Invalid))
                 {
                     await message.RemoveReactionAsync(input.Emote, input.UserId).ConfigureAwait(false);
                 }
@@ -317,7 +327,7 @@ namespace Fergun.Interactive.Selection
                 return new(InteractiveInputStatus.Canceled, selected);
             }
 
-            if (Deletion.HasFlag(DeletionOptions.Valid))
+            if (manageMessages && Deletion.HasFlag(DeletionOptions.Valid))
             {
                 await message.RemoveReactionAsync(input.Emote, input.UserId).ConfigureAwait(false);
             }
@@ -331,6 +341,9 @@ namespace Fergun.Interactive.Selection
 
         private InteractiveInputResult<TOption> HandleInteraction(SocketInteraction input, IUserMessage message)
         {
+            InteractiveGuards.NotNull(input, nameof(input));
+            InteractiveGuards.NotNull(message, nameof(message));
+
             if ((!InputType.HasFlag(InputType.Buttons) && !InputType.HasFlag(InputType.SelectMenus)) || input is not SocketMessageComponent interaction)
             {
                 return InteractiveInputStatus.Ignored;

--- a/src/Selection/SelectionCallback.cs
+++ b/src/Selection/SelectionCallback.cs
@@ -59,7 +59,7 @@ namespace Fergun.Interactive.Selection
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketMessage message)
         {
-            var result = await Selection.HandleMessageAsync(message, Message);
+            var result = await Selection.HandleMessageAsync(message, Message).ConfigureAwait(false);
 
             switch (result.Status)
             {
@@ -80,7 +80,7 @@ namespace Fergun.Interactive.Selection
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketReaction reaction)
         {
-            var result = await Selection.HandleReactionAsync(reaction, Message);
+            var result = await Selection.HandleReactionAsync(reaction, Message).ConfigureAwait(false);
 
             switch (result.Status)
             {
@@ -101,7 +101,7 @@ namespace Fergun.Interactive.Selection
         /// <inheritdoc/>
         public async Task ExecuteAsync(SocketInteraction interaction)
         {
-            var result = await Selection.HandleInteractionAsync(interaction, Message);
+            var result = await Selection.HandleInteractionAsync(interaction, Message).ConfigureAwait(false);
 
             switch (result.Status)
             {


### PR DESCRIPTION
This PR adds support for custom input handling in paginators and selections. This will further improve the customizability of paginators/selections.

## Additions

- New interface `IInteractiveInputHandler`. It provides methods for handling inputs (messages, reactions, interactions).
- New interface `IElapsed`. It provides an `Elapsed` (`TimeSpan`) property.
- New class `InteractiveInputResult`, used in the return type of input handlers in paginators/selections.
- New class `InteractiveInputResult<TOption>`, a generic variant of `InteractiveInputResult`.
- New enum `InteractiveInputStatus`. It specifies the possible status in the result of an input handler.

## Changes

- `IInteractiveElement` now implements `IInteractiveInputHandler`.
- `IInteractiveResult` is now a generic interface of `TStatus`, with an `Enum` constraint.
- `IInteractiveMessageResult` now implements `IInteractiveResult<InteractiveStatus>` and `IElapsed`.
- `InteractiveResult` now implements `IInteractiveResult<InteractiveStatus>` and `IElapsed`.
- Now the input handling logic of paginators/selections is exposed in the paginators/selections themselves in the `HandleMessageAsync`/`HandleReactionAsync`/`HandleInteractionAsync` methods. These methods will have a default implementation, which are based on the internal input handlers that were used before.