### PR TITLE
Improved constructors for paginators/selections

### DIFF
--- a/ExampleBot/Modules/CustomButtonModule.cs
+++ b/ExampleBot/Modules/CustomButtonModule.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -52,21 +50,14 @@ public partial class CustomModule : ModuleBase
         public override InputType InputType => InputType.Buttons;
 
         // We must override the Build method
-        public override ButtonSelection<T> Build() => new(EmoteConverter, StringConverter,
-            EqualityComparer, AllowCancel, SelectionPage?.Build(), Users?.ToArray(), Options?.ToArray(),
-            CanceledPage?.Build(), TimeoutPage?.Build(), SuccessPage?.Build(), Deletion, InputType,
-            ActionOnCancellation, ActionOnTimeout, ActionOnSuccess);
+        public override ButtonSelection<T> Build() => new(this);
     }
 
     // Custom selection where you can override the default button style/color
     public class ButtonSelection<T> : BaseSelection<ButtonOption<T>>
     {
-        public ButtonSelection(Func<ButtonOption<T>, IEmote> emoteConverter, Func<ButtonOption<T>, string> stringConverter,
-            IEqualityComparer<ButtonOption<T>> equalityComparer, bool allowCancel, Page selectionPage, IReadOnlyCollection<IUser> users,
-            IReadOnlyCollection<ButtonOption<T>> options, Page canceledPage, Page timeoutPage, Page successPage, DeletionOptions deletion,
-            InputType inputType, ActionOnStop actionOnCancellation, ActionOnStop actionOnTimeout, ActionOnStop actionOnSuccess)
-            : base(emoteConverter, stringConverter, equalityComparer, allowCancel, selectionPage, users, options, canceledPage,
-                timeoutPage, successPage, deletion, inputType, actionOnCancellation, actionOnTimeout, actionOnSuccess)
+        public ButtonSelection(ButtonSelectionBuilder<T> builder)
+            : base(builder)
         {
         }
 

--- a/ExampleBot/Modules/CustomSelectModule.cs
+++ b/ExampleBot/Modules/CustomSelectModule.cs
@@ -108,20 +108,13 @@ public class MultiSelectionBuilder<T> : BaseSelectionBuilder<MultiSelection<T>, 
 {
     public override InputType InputType => InputType.SelectMenus;
 
-    public override MultiSelection<T> Build() => new(EmoteConverter, StringConverter,
-        EqualityComparer, AllowCancel, SelectionPage?.Build(), Users?.ToArray(), Options?.ToArray(),
-        CanceledPage?.Build(), TimeoutPage?.Build(), SuccessPage?.Build(), Deletion, InputType,
-        ActionOnCancellation, ActionOnTimeout, ActionOnSuccess);
+    public override MultiSelection<T> Build() => new(this);
 }
 
 public class MultiSelection<T> : BaseSelection<MultiSelectionOption<T>>
 {
-    public MultiSelection(Func<MultiSelectionOption<T>, IEmote> emoteConverter, Func<MultiSelectionOption<T>, string> stringConverter,
-        IEqualityComparer<MultiSelectionOption<T>> equalityComparer, bool allowCancel, Page selectionPage, IReadOnlyCollection<IUser> users,
-        IReadOnlyCollection<MultiSelectionOption<T>> options, Page canceledPage, Page timeoutPage, Page successPage, DeletionOptions deletion,
-        InputType inputType, ActionOnStop actionOnCancellation, ActionOnStop actionOnTimeout, ActionOnStop actionOnSuccess)
-        : base(emoteConverter, stringConverter, equalityComparer, allowCancel, selectionPage, users, options, canceledPage,
-            timeoutPage, successPage, deletion, inputType, actionOnCancellation, actionOnTimeout, actionOnSuccess)
+    public MultiSelection(MultiSelectionBuilder<T> builder)
+        : base(builder)
     {
     }
 

--- a/src/Entities/IInteractiveBuilder.cs
+++ b/src/Entities/IInteractiveBuilder.cs
@@ -154,6 +154,4 @@ namespace Fergun.Interactive
         /// <returns>This builder.</returns>
         TBuilder WithActionOnTimeout(ActionOnStop action);
     }
-
-    
 }

--- a/src/Entities/IInteractiveBuilder.cs
+++ b/src/Entities/IInteractiveBuilder.cs
@@ -10,36 +10,45 @@ namespace Fergun.Interactive
     /// <typeparam name="TOption">The type of the options.</typeparam>
     /// <typeparam name="TBuilder">The type of this builder.</typeparam>
     public interface IInteractiveBuilder<out TElement, TOption, out TBuilder>
+        : IInteractiveBuilderProperties<TOption>, IInteractiveBuilderMethods<TElement, TOption, TBuilder>
         where TElement : IInteractiveElement<TOption>
         where TBuilder : IInteractiveBuilder<TElement, TOption, TBuilder>
     {
+    }
+
+    /// <summary>
+    /// Contains the properties of an <see cref="IInteractiveBuilder{TElement, TOption, TBuilder}"/>.
+    /// </summary>
+    /// <typeparam name="TOption">The type of the options.</typeparam>
+    public interface IInteractiveBuilderProperties<TOption>
+    {
         /// <summary>
-        /// Gets or sets the users who can interact with the <typeparamref name="TElement"/>.
+        /// Gets or sets the users who can interact with the element.
         /// </summary>
         ICollection<IUser> Users { get; set; }
 
         /// <summary>
-        /// Gets or sets a collection of inputs.
+        /// Gets or sets a collection of options.
         /// </summary>
         ICollection<TOption> Options { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Page"/> which the <typeparamref name="TElement"/> gets modified to after cancellation.
+        /// Gets or sets the <see cref="Page"/> which the element gets modified to after cancellation.
         /// </summary>
         PageBuilder? CanceledPage { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Page"/> which the <typeparamref name="TElement"/> gets modified to after a timeout.
+        /// Gets or sets the <see cref="Page"/> which the element gets modified to after a timeout.
         /// </summary>
         PageBuilder? TimeoutPage { get; set; }
 
         /// <summary>
-        /// Gets or sets what type of inputs the <typeparamref name="TElement"/> should delete.
+        /// Gets or sets what type of inputs the element should delete.
         /// </summary>
         DeletionOptions Deletion { get; set; }
 
         /// <summary>
-        /// Gets or sets the input type, that is, what is used to interact with the <typeparamref name="TElement"/>.
+        /// Gets or sets the input type, that is, what is used to interact with the element.
         /// </summary>
         InputType InputType { get; set; }
 
@@ -52,7 +61,16 @@ namespace Fergun.Interactive
         /// Gets or sets the action that will be done after a timeout.
         /// </summary>
         ActionOnStop ActionOnTimeout { get; set; }
+    }
 
+    /// <summary>
+    /// Provides a fluent interface for <see cref="IInteractiveBuilder{TElement, TOption, TBuilder}"/>.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the built element.</typeparam>
+    /// <typeparam name="TOption">The type of the options.</typeparam>
+    /// <typeparam name="TBuilder">The type of this builder.</typeparam>
+    public interface IInteractiveBuilderMethods<out TElement, TOption, out TBuilder>
+    {
         /// <summary>
         /// Builds this interactive builder to an immutable <typeparamref name="TElement"/>.
         /// </summary>
@@ -136,4 +154,6 @@ namespace Fergun.Interactive
         /// <returns>This builder.</returns>
         TBuilder WithActionOnTimeout(ActionOnStop action);
     }
+
+    
 }

--- a/src/Entities/Page/PageBuilder.cs
+++ b/src/Entities/Page/PageBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Discord;
 using Fergun.Interactive.Pagination;
 
@@ -397,7 +398,7 @@ namespace Fergun.Interactive
             return this;
         }
 
-        internal PageBuilder WithPaginatorFooter(PaginatorFooter footer, int page, int totalPages, IList<IUser>? users)
+        internal PageBuilder WithPaginatorFooter(PaginatorFooter footer, int page, int totalPages, ICollection<IUser>? users)
         {
             if (footer == PaginatorFooter.None)
             {
@@ -413,7 +414,7 @@ namespace Fergun.Interactive
                 }
                 else if (users.Count == 1)
                 {
-                    var user = users[0];
+                    var user = users.First();
 
                     Footer.IconUrl = user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl();
                     Footer.Text += $"Interactor: {user}\n";

--- a/src/InteractiveExtensions.cs
+++ b/src/InteractiveExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Discord;
 using Fergun.Interactive.Pagination;
@@ -52,5 +54,8 @@ namespace Fergun.Interactive
         // Using just startTime.GetElapsedTime() would return a slightly incorrect elapsed time if the status is Timeout
         public static TimeSpan GetElapsedTime(this InteractiveStatus status, DateTimeOffset startTime, TimeSpan timeoutDelay)
             => status == InteractiveStatus.Timeout ? timeoutDelay : startTime.GetElapsedTime();
+
+        public static IReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+            => new ReadOnlyDictionary<TKey, TValue>(dictionary);
     }
 }

--- a/src/InteractiveGuards.cs
+++ b/src/InteractiveGuards.cs
@@ -33,6 +33,14 @@ namespace Fergun.Interactive
             }
         }
 
+        public static void IndexInRange<T>(ICollection<T> collection, int index, string parameterName)
+        {
+            if (index < 0 || index + 1 >= collection.Count)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, index, $"Index must be greater than or equal to 0 and lower than {collection.Count}.");
+            }
+        }
+
         public static void MessageFromCurrentUser(BaseSocketClient client, IUserMessage? message, string parameterName)
         {
             if (message is not null && message.Author.Id != client.CurrentUser.Id)

--- a/src/InteractiveGuards.cs
+++ b/src/InteractiveGuards.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Discord;
 using Discord.WebSocket;
 using Fergun.Interactive.Pagination;
@@ -12,6 +14,22 @@ namespace Fergun.Interactive
             if (obj is null)
             {
                 throw new ArgumentNullException(parameterName);
+            }
+        }
+
+        public static void NotEmpty<T>(ICollection<T> collection, string parameterName)
+        {
+            if (collection.Count == 0)
+            {
+                throw new ArgumentException("Collection must not be empty.", parameterName);
+            }
+        }
+
+        public static void NoDuplicates<TOption>(ICollection<TOption> collection, IEqualityComparer<TOption> equalityComparer, string parameterName)
+        {
+            if (collection.Distinct(equalityComparer).Count() != collection.Count)
+            {
+                throw new ArgumentException("Collection must not contain duplicate elements.", parameterName);
             }
         }
 
@@ -36,17 +54,22 @@ namespace Fergun.Interactive
             }
         }
 
-        public static void SupportedInputType<TOption>(IInteractiveElement<TOption> element, bool ephemeral)
+        public static void SupportedInputType(InputType inputType, bool ephemeral)
         {
-            if (element.InputType == 0)
+            if (inputType == 0)
             {
                 throw new ArgumentException("At least one input type must be set.");
             }
 
-            if (ephemeral && element.InputType.HasFlag(InputType.Reactions))
+            if (ephemeral && inputType.HasFlag(InputType.Reactions))
             {
                 throw new NotSupportedException("Ephemeral messages cannot use reactions as input.");
             }
+        }
+
+        public static void SupportedInputType<TOption>(IInteractiveElement<TOption> element, bool ephemeral)
+        {
+            SupportedInputType(element.InputType, ephemeral);
 
             if (element is Paginator paginator)
             {
@@ -59,6 +82,14 @@ namespace Fergun.Interactive
                 {
                     throw new NotSupportedException("Paginators using select menus as input are not supported (yet).");
                 }
+            }
+        }
+
+        public static void RequiredEmoteConverter<TOption>(InputType inputType, Func<TOption, IEmote>? emoteConverter)
+        {
+            if (inputType.HasFlag(InputType.Reactions) && emoteConverter is null)
+            {
+                throw new ArgumentNullException(nameof(emoteConverter), $"{nameof(emoteConverter)} is required when {nameof(inputType)} has InputType.Reactions.");
             }
         }
 

--- a/src/Pagination/Lazy/LazyPaginator.cs
+++ b/src/Pagination/Lazy/LazyPaginator.cs
@@ -26,8 +26,8 @@ namespace Fergun.Interactive.Pagination
         [MemberNotNullWhen(true, nameof(_cachedPages))]
         public bool CacheLoadedPages { get; }
 
-        internal LazyPaginator(LazyPaginatorBuilder builder, int startPageIndex)
-            : base(builder, startPageIndex)
+        internal LazyPaginator(LazyPaginatorBuilder builder)
+            : base(builder)
         {
             InteractiveGuards.NotNull(builder.PageFactory, nameof(builder.PageFactory));
 

--- a/src/Pagination/Lazy/LazyPaginatorBuilder.cs
+++ b/src/Pagination/Lazy/LazyPaginatorBuilder.cs
@@ -31,14 +31,14 @@ namespace Fergun.Interactive.Pagination
         }
 
         /// <inheritdoc/>
-        public override LazyPaginator Build(int startPageIndex = 0)
+        public override LazyPaginator Build()
         {
             if (Options.Count == 0)
             {
                 WithDefaultEmotes();
             }
 
-            return new LazyPaginator(this, startPageIndex);
+            return new LazyPaginator(this);
         }
 
         /// <summary>

--- a/src/Pagination/Lazy/LazyPaginatorBuilder.cs
+++ b/src/Pagination/Lazy/LazyPaginatorBuilder.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading.Tasks;
-using Discord;
 
 namespace Fergun.Interactive.Pagination
 {
@@ -41,28 +38,7 @@ namespace Fergun.Interactive.Pagination
                 WithDefaultEmotes();
             }
 
-            return new LazyPaginator(
-                Users.ToArray(),
-                new ReadOnlyDictionary<IEmote, PaginatorAction>(Options), // TODO: Find a way to create an ImmutableDictionary without getting the contents reordered.
-                CanceledPage?.Build(),
-                TimeoutPage?.Build(),
-                Deletion,
-                InputType,
-                ActionOnCancellation,
-                ActionOnTimeout,
-                PageFactory != null! ? AddPaginatorFooterAsync : null!,
-                startPageIndex,
-                MaxPageIndex,
-                CacheLoadedPages);
-
-            async Task<Page> AddPaginatorFooterAsync(int page)
-            {
-                var builder = await PageFactory(page).ConfigureAwait(false);
-
-                return builder
-                    .WithPaginatorFooter(Footer, page, MaxPageIndex, Users)
-                    .Build();
-            }
+            return new LazyPaginator(this, startPageIndex);
         }
 
         /// <summary>

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -66,11 +66,11 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc/>
         IReadOnlyCollection<KeyValuePair<IEmote, PaginatorAction>> IInteractiveElement<KeyValuePair<IEmote, PaginatorAction>>.Options => Emotes;
 
-        //protected Paginator(IInteractiveBuilderProperties<KeyValuePair<IEmote, PaginatorAction>> builder, int startPageIndex)
         /// <summary>
         /// Initializes a new instance of the <see cref="Paginator"/> class.
         /// </summary>
-        protected Paginator(PaginatorBuilderProperties builder, int startPageIndex)
+        /// <param name="builder">The builder to copy the properties from.</param>
+        protected Paginator(PaginatorBuilderProperties builder)
         {
             InteractiveGuards.NotNull(builder, nameof(builder));
             InteractiveGuards.NotNull(builder.Users, nameof(builder.Users));
@@ -86,7 +86,7 @@ namespace Fergun.Interactive.Pagination
             InputType = builder.InputType;
             ActionOnCancellation = builder.ActionOnCancellation;
             ActionOnTimeout = builder.ActionOnTimeout;
-            CurrentPageIndex = startPageIndex;
+            CurrentPageIndex = builder.StartPageIndex;
         }
 
         /// <summary>

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord;
@@ -66,37 +66,26 @@ namespace Fergun.Interactive.Pagination
         /// <inheritdoc/>
         IReadOnlyCollection<KeyValuePair<IEmote, PaginatorAction>> IInteractiveElement<KeyValuePair<IEmote, PaginatorAction>>.Options => Emotes;
 
+        //protected Paginator(IInteractiveBuilderProperties<KeyValuePair<IEmote, PaginatorAction>> builder, int startPageIndex)
         /// <summary>
         /// Initializes a new instance of the <see cref="Paginator"/> class.
         /// </summary>
-        protected Paginator(IReadOnlyCollection<IUser> users, IReadOnlyDictionary<IEmote, PaginatorAction> emotes,
-            Page? canceledPage, Page? timeoutPage, DeletionOptions deletion, InputType inputType,
-            ActionOnStop actionOnCancellation, ActionOnStop actionOnTimeout, int startPageIndex)
+        protected Paginator(PaginatorBuilderProperties builder, int startPageIndex)
         {
-            Users = users ?? throw new ArgumentNullException(nameof(users));
+            InteractiveGuards.NotNull(builder, nameof(builder));
+            InteractiveGuards.NotNull(builder.Users, nameof(builder.Users));
+            InteractiveGuards.NotNull(builder.Options, nameof(builder.Options));
+            InteractiveGuards.NotEmpty(builder.Options, nameof(builder.Options));
+            InteractiveGuards.SupportedInputType(builder.InputType, false);
 
-            if (inputType == 0)
-            {
-                throw new ArgumentException("At least one input type must be set.", nameof(inputType));
-            }
-
-            if (emotes is null)
-            {
-                throw new ArgumentNullException(nameof(emotes));
-            }
-
-            if (emotes.Count == 0)
-            {
-                throw new ArgumentException($"{nameof(emotes)} must contain at least one element.", nameof(emotes));
-            }
-
-            Emotes = emotes;
-            CanceledPage = canceledPage;
-            TimeoutPage = timeoutPage;
-            Deletion = deletion;
-            InputType = inputType;
-            ActionOnCancellation = actionOnCancellation;
-            ActionOnTimeout = actionOnTimeout;
+            Users = builder.Users.ToArray();
+            Emotes = builder.Options.AsReadOnly();
+            CanceledPage = builder.CanceledPage?.Build();
+            TimeoutPage = builder.TimeoutPage?.Build();
+            Deletion = builder.Deletion;
+            InputType = builder.InputType;
+            ActionOnCancellation = builder.ActionOnCancellation;
+            ActionOnTimeout = builder.ActionOnTimeout;
             CurrentPageIndex = startPageIndex;
         }
 

--- a/src/Pagination/PaginatorBuilder.cs
+++ b/src/Pagination/PaginatorBuilder.cs
@@ -16,6 +16,11 @@ namespace Fergun.Interactive.Pagination
         public virtual bool IsUserRestricted => Users.Count > 0;
 
         /// <summary>
+        /// Gets or sets the index of the page the paginator should start.
+        /// </summary>
+        public virtual int StartPageIndex { get; set; }
+
+        /// <summary>
         /// Gets or sets the footer format in the <see cref="Embed"/> of the paginator.
         /// </summary>
         /// <remarks>Setting this to other than <see cref="PaginatorFooter.None"/> will override any other footer in the pages.</remarks>
@@ -71,9 +76,19 @@ namespace Fergun.Interactive.Pagination
         /// <summary>
         /// Builds this <typeparamref name="TBuilder"/> into an immutable <typeparamref name="TPaginator"/>.
         /// </summary>
-        /// <param name="startPageIndex">The index of the page the paginator should start.</param>
         /// <returns>A <typeparamref name="TPaginator"/>.</returns>
-        public abstract TPaginator Build(int startPageIndex = 0);
+        public abstract TPaginator Build();
+
+        /// <summary>
+        /// Sets the index of the page the <typeparamref name="TPaginator"/> should start.
+        /// </summary>
+        /// <param name="startPageIndex">The index of the page the <typeparamref name="TPaginator"/> should start.</param>
+        /// <returns>This builder.</returns>
+        public virtual TBuilder WithStartPageIndex(int startPageIndex)
+        {
+            StartPageIndex = startPageIndex;
+            return (TBuilder)this;
+        }
 
         /// <summary>
         /// Gets the footer format in the <see cref="Embed"/> of the <typeparamref name="TPaginator"/>.

--- a/src/Pagination/PaginatorBuilder.cs
+++ b/src/Pagination/PaginatorBuilder.cs
@@ -6,12 +6,9 @@ using Discord;
 namespace Fergun.Interactive.Pagination
 {
     /// <summary>
-    /// Represents an abstract paginator builder.
+    /// Represents the properties of a <see cref="PaginatorBuilder{TPaginator, TBuilder}"/>
     /// </summary>
-    public abstract class PaginatorBuilder<TPaginator, TBuilder>
-        : IInteractiveBuilder<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>
-        where TPaginator : Paginator
-        where TBuilder : PaginatorBuilder<TPaginator, TBuilder>
+    public abstract class PaginatorBuilderProperties : IInteractiveBuilderProperties<KeyValuePair<IEmote, PaginatorAction>>
     {
         /// <summary>
         /// Gets whether the paginator is restricted to <see cref="Users"/>.
@@ -19,18 +16,18 @@ namespace Fergun.Interactive.Pagination
         public virtual bool IsUserRestricted => Users.Count > 0;
 
         /// <summary>
-        /// Gets or sets the footer format in the <see cref="Embed"/> of the <typeparamref name="TPaginator"/>.
+        /// Gets or sets the footer format in the <see cref="Embed"/> of the paginator.
         /// </summary>
         /// <remarks>Setting this to other than <see cref="PaginatorFooter.None"/> will override any other footer in the pages.</remarks>
         public virtual PaginatorFooter Footer { get; set; } = PaginatorFooter.PageNumber;
 
         /// <summary>
-        /// Gets or sets the users who can interact with the <typeparamref name="TPaginator"/>.
+        /// Gets or sets the users who can interact with the paginator.
         /// </summary>
-        public virtual IList<IUser> Users { get; set; } = new List<IUser>();
+        public virtual ICollection<IUser> Users { get; set; } = new List<IUser>();
 
         /// <summary>
-        /// Gets or sets the emotes and their related actions of the <typeparamref name="TPaginator"/>.
+        /// Gets or sets the emotes and their related actions of the paginator.
         /// </summary>
         public virtual IDictionary<IEmote, PaginatorAction> Options { get; set; } = new Dictionary<IEmote, PaginatorAction>();
 
@@ -56,20 +53,23 @@ namespace Fergun.Interactive.Pagination
         public virtual ActionOnStop ActionOnTimeout { get; set; } = ActionOnStop.ModifyMessage;
 
         /// <inheritdoc/>
-        ICollection<KeyValuePair<IEmote, PaginatorAction>> IInteractiveBuilder<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.Options
+        ICollection<KeyValuePair<IEmote, PaginatorAction>> IInteractiveBuilderProperties<KeyValuePair<IEmote, PaginatorAction>>.Options
         {
             get => Options;
             set => Options = value?.ToDictionary(x => x.Key, x => x.Value) ?? throw new ArgumentNullException(nameof(value));
         }
+    }
 
-        ICollection<IUser> IInteractiveBuilder<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.Users
-        {
-            get => Users;
-            set => Users = value?.ToList() ?? throw new ArgumentNullException(nameof(value));
-        }
-
+    /// <summary>
+    /// Represents an abstract paginator builder.
+    /// </summary>
+    public abstract class PaginatorBuilder<TPaginator, TBuilder>
+        : PaginatorBuilderProperties, IInteractiveBuilderMethods<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>
+        where TPaginator : Paginator
+        where TBuilder : PaginatorBuilder<TPaginator, TBuilder>
+    {
         /// <summary>
-        /// Builds the <see cref="PaginatorBuilder{TPaginator, TBuilder}"/> to an immutable paginator.
+        /// Builds this <typeparamref name="TBuilder"/> into an immutable <typeparamref name="TPaginator"/>.
         /// </summary>
         /// <param name="startPageIndex">The index of the page the paginator should start.</param>
         /// <returns>A <typeparamref name="TPaginator"/>.</returns>
@@ -233,10 +233,10 @@ namespace Fergun.Interactive.Pagination
             => WithTimeoutPage(new PageBuilder().WithColor(Color.Red).WithTitle("Timed out! ⏰"));
 
         /// <inheritdoc/>
-        TPaginator IInteractiveBuilder<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.Build() => Build();
+        TPaginator IInteractiveBuilderMethods<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.Build() => Build();
 
         /// <inheritdoc/>
-        TBuilder IInteractiveBuilder<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.WithOptions(ICollection<KeyValuePair<IEmote, PaginatorAction>> options)
+        TBuilder IInteractiveBuilderMethods<TPaginator, KeyValuePair<IEmote, PaginatorAction>, TBuilder>.WithOptions(ICollection<KeyValuePair<IEmote, PaginatorAction>> options)
             => WithOptions(options.ToDictionary(x => x.Key, x => x.Value));
     }
 }

--- a/src/Pagination/PaginatorBuilder.cs
+++ b/src/Pagination/PaginatorBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Discord;
 
@@ -29,7 +30,7 @@ namespace Fergun.Interactive.Pagination
         /// <summary>
         /// Gets or sets the users who can interact with the paginator.
         /// </summary>
-        public virtual ICollection<IUser> Users { get; set; } = new List<IUser>();
+        public virtual ICollection<IUser> Users { get; set; } = new Collection<IUser>();
 
         /// <summary>
         /// Gets or sets the emotes and their related actions of the paginator.

--- a/src/Pagination/Static/StaticPaginator.cs
+++ b/src/Pagination/Static/StaticPaginator.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Discord;
 
 namespace Fergun.Interactive.Pagination
 {
@@ -12,31 +10,22 @@ namespace Fergun.Interactive.Pagination
     public sealed class StaticPaginator : Paginator
     {
         /// <summary>
-        /// Gets the pages of the <see cref="Paginator"/>.
+        /// Gets the pages of this paginator.
         /// </summary>
         public IReadOnlyCollection<Page> Pages { get; }
 
         /// <summary>
-        /// Gets the maximum page index of the <see cref="Paginator"/>.
+        /// Gets the maximum page index of this paginator.
         /// </summary>
         public override int MaxPageIndex => Pages.Count - 1;
 
-        internal StaticPaginator(IReadOnlyCollection<IUser> users, IReadOnlyDictionary<IEmote, PaginatorAction> emotes,
-            Page? canceledPage, Page? timeoutPage, DeletionOptions deletion, InputType inputType,
-            ActionOnStop actionOnCancellation, ActionOnStop actionOnTimeout, IReadOnlyCollection<Page> pages, int startPageIndex)
-            : base(users, emotes, canceledPage, timeoutPage, deletion, inputType, actionOnCancellation, actionOnTimeout, startPageIndex)
+        internal StaticPaginator(StaticPaginatorBuilder builder, int startPageIndex)
+            : base(builder, startPageIndex)
         {
-            if (pages is null)
-            {
-                throw new ArgumentNullException(nameof(pages));
-            }
+            InteractiveGuards.NotNull(builder.Pages, nameof(builder.Pages));
+            InteractiveGuards.NotEmpty(builder.Pages, nameof(builder.Pages));
 
-            if (pages.Count == 0)
-            {
-                throw new ArgumentException("A paginator needs at least one page.", nameof(pages));
-            }
-
-            Pages = pages;
+            Pages = builder.Pages.Select((x, i) => x.WithPaginatorFooter(builder.Footer, i, builder.Pages.Count - 1, builder.Users).Build()).ToArray();
         }
 
         /// <inheritdoc/>

--- a/src/Pagination/Static/StaticPaginator.cs
+++ b/src/Pagination/Static/StaticPaginator.cs
@@ -19,11 +19,12 @@ namespace Fergun.Interactive.Pagination
         /// </summary>
         public override int MaxPageIndex => Pages.Count - 1;
 
-        internal StaticPaginator(StaticPaginatorBuilder builder, int startPageIndex)
-            : base(builder, startPageIndex)
+        internal StaticPaginator(StaticPaginatorBuilder builder)
+            : base(builder)
         {
             InteractiveGuards.NotNull(builder.Pages, nameof(builder.Pages));
             InteractiveGuards.NotEmpty(builder.Pages, nameof(builder.Pages));
+            InteractiveGuards.IndexInRange(builder.Pages, builder.StartPageIndex, nameof(builder.StartPageIndex));
 
             Pages = builder.Pages.Select((x, i) => x.WithPaginatorFooter(builder.Footer, i, builder.Pages.Count - 1, builder.Users).Build()).ToArray();
         }

--- a/src/Pagination/Static/StaticPaginatorBuilder.cs
+++ b/src/Pagination/Static/StaticPaginatorBuilder.cs
@@ -22,14 +22,14 @@ namespace Fergun.Interactive.Pagination
         }
 
         /// <inheritdoc/>
-        public override StaticPaginator Build(int startPageIndex = 0)
+        public override StaticPaginator Build()
         {
             if (Options.Count == 0)
             {
                 WithDefaultEmotes();
             }
 
-            return new StaticPaginator(this, startPageIndex);
+            return new StaticPaginator(this);
         }
 
         /// <summary>

--- a/src/Pagination/Static/StaticPaginatorBuilder.cs
+++ b/src/Pagination/Static/StaticPaginatorBuilder.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using Discord;
 
 namespace Fergun.Interactive.Pagination
 {
@@ -12,7 +10,7 @@ namespace Fergun.Interactive.Pagination
     public sealed class StaticPaginatorBuilder : PaginatorBuilder<StaticPaginator, StaticPaginatorBuilder>
     {
         /// <summary>
-        /// Gets or sets the pages of the <see cref="Paginator"/>.
+        /// Gets or sets the pages of the paginator.
         /// </summary>
         public IList<PageBuilder> Pages { get; set; } = new List<PageBuilder>();
 
@@ -31,17 +29,7 @@ namespace Fergun.Interactive.Pagination
                 WithDefaultEmotes();
             }
 
-            return new StaticPaginator(
-                Users.ToArray(),
-                new ReadOnlyDictionary<IEmote, PaginatorAction>(Options), // TODO: Find a way to create an ImmutableDictionary without getting the contents reordered.
-                CanceledPage?.Build(),
-                TimeoutPage?.Build(),
-                Deletion,
-                InputType,
-                ActionOnCancellation,
-                ActionOnTimeout,
-                Pages.Select((x, i) => x.WithPaginatorFooter(Footer, i, Pages.Count - 1, Users).Build()).ToArray(),
-                startPageIndex);
+            return new StaticPaginator(this, startPageIndex);
         }
 
         /// <summary>

--- a/src/Selection/BaseSelection.cs
+++ b/src/Selection/BaseSelection.cs
@@ -87,60 +87,40 @@ namespace Fergun.Interactive.Selection
         public ActionOnStop ActionOnSuccess { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BaseSelection{TOption}"/> class.
+        /// Initializes a new instance of the <see cref="BaseSelection{TOption}"/> class using the specified builder properties.
         /// </summary>
-        protected BaseSelection(Func<TOption, IEmote>? emoteConverter, Func<TOption, string>? stringConverter, IEqualityComparer<TOption> equalityComparer,
-            bool allowCancel, Page selectionPage, IReadOnlyCollection<IUser> users, IReadOnlyCollection<TOption> options, Page? canceledPage,
-            Page? timeoutPage, Page? successPage, DeletionOptions deletion, InputType inputType, ActionOnStop actionOnCancellation,
-            ActionOnStop actionOnTimeout, ActionOnStop actionOnSuccess)
+        /// <param name="builder">The builder to copy the properties from.</param>
+        protected BaseSelection(BaseSelectionBuilderProperties<TOption> builder)
         {
-            if (inputType == 0)
+            InteractiveGuards.SupportedInputType(builder.InputType, false);
+            InteractiveGuards.RequiredEmoteConverter(builder.InputType, builder.EmoteConverter);
+            InteractiveGuards.NotNull(builder.EqualityComparer, nameof(builder.EqualityComparer));
+            InteractiveGuards.NotNull(builder.SelectionPage, nameof(builder.SelectionPage));
+            InteractiveGuards.NotNull(builder.Options, nameof(builder.Options));
+            InteractiveGuards.NotNull(builder.Users, nameof(builder.Users));
+            InteractiveGuards.NotEmpty(builder.Options, nameof(builder.Options));
+
+            StringConverter = builder.StringConverter;
+            EmoteConverter = builder.EmoteConverter;
+            EqualityComparer = builder.EqualityComparer;
+            SelectionPage = builder.SelectionPage.Build();
+            AllowCancel = builder.AllowCancel && builder.Options.Count > 1;
+            CancelOption = AllowCancel ? builder.Options.Last() : default;
+            Users = builder.Users.ToArray();
+            Options = builder.Options.ToArray();
+            CanceledPage = builder.CanceledPage?.Build();
+            TimeoutPage = builder.TimeoutPage?.Build();
+            SuccessPage = builder.SuccessPage?.Build();
+            Deletion = builder.Deletion;
+            InputType = builder.InputType;
+            ActionOnCancellation = builder.ActionOnCancellation;
+            ActionOnTimeout = builder.ActionOnTimeout;
+            ActionOnSuccess = builder.ActionOnSuccess;
+
+            if (StringConverter is null && (!InputType.HasFlag(InputType.Buttons) || EmoteConverter is null))
             {
-                throw new ArgumentException("At least one input type must be set.", nameof(inputType));
+                StringConverter = x => x?.ToString()!;
             }
-
-            if (inputType.HasFlag(InputType.Reactions) && emoteConverter is null)
-            {
-                throw new ArgumentNullException(nameof(emoteConverter), $"{nameof(emoteConverter)} is required when {nameof(inputType)} has InputType.Reactions.");
-            }
-
-            if (stringConverter is null && (!inputType.HasFlag(InputType.Buttons) || emoteConverter is null))
-            {
-                stringConverter = x => x?.ToString()!;
-            }
-
-            EmoteConverter = emoteConverter;
-            StringConverter = stringConverter;
-            EqualityComparer = equalityComparer ?? throw new ArgumentNullException(nameof(equalityComparer));
-            SelectionPage = selectionPage ?? throw new ArgumentNullException(nameof(selectionPage));
-
-            if (options is null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-
-            if (options.Count == 0)
-            {
-                throw new ArgumentException($"{nameof(options)} must contain at least one element.", nameof(options));
-            }
-
-            if (options.Distinct(EqualityComparer).Count() != options.Count)
-            {
-                throw new ArgumentException($"{nameof(options)} must not contain duplicate elements.", nameof(options));
-            }
-
-            AllowCancel = allowCancel && options.Count > 1;
-            CancelOption = AllowCancel ? options.Last() : default;
-            Users = users ?? throw new ArgumentNullException(nameof(users));
-            Options = options;
-            CanceledPage = canceledPage;
-            TimeoutPage = timeoutPage;
-            SuccessPage = successPage;
-            Deletion = deletion;
-            InputType = inputType;
-            ActionOnCancellation = actionOnCancellation;
-            ActionOnTimeout = actionOnTimeout;
-            ActionOnSuccess = actionOnSuccess;
         }
 
         /// <summary>

--- a/src/Selection/BaseSelectionBuilder.cs
+++ b/src/Selection/BaseSelectionBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Discord;
 
@@ -60,12 +61,12 @@ namespace Fergun.Interactive.Selection
         /// <summary>
         /// Gets or sets the users who can interact with the <see cref="BaseSelection{TOption}"/>.
         /// </summary>
-        public virtual ICollection<IUser> Users { get; set; } = new List<IUser>();
+        public virtual ICollection<IUser> Users { get; set; } = new Collection<IUser>();
 
         /// <summary>
         /// Gets or sets the options to select from.
         /// </summary>
-        public virtual ICollection<TOption> Options { get; set; } = new List<TOption>();
+        public virtual ICollection<TOption> Options { get; set; } = new Collection<TOption>();
 
         /// <inheritdoc />
         public virtual PageBuilder? CanceledPage { get; set; }

--- a/src/Selection/BaseSelectionBuilder.cs
+++ b/src/Selection/BaseSelectionBuilder.cs
@@ -6,14 +6,10 @@ using Discord;
 namespace Fergun.Interactive.Selection
 {
     /// <summary>
-    /// Represents the base of the selection builders. Custom selection builders should inherit this class to allow fluent interface usage.
+    /// Represents the properties in a <see cref="BaseSelectionBuilder{TSelection, TOption, TBuilder}"/>
     /// </summary>
-    /// <typeparam name="TSelection">The type of the built selection.</typeparam>
     /// <typeparam name="TOption">The type of the options the selection will have.</typeparam>
-    /// <typeparam name="TBuilder">The type of this builder.</typeparam>
-    public abstract class BaseSelectionBuilder<TSelection, TOption, TBuilder> : IInteractiveBuilder<TSelection, TOption, TBuilder>
-        where TSelection : BaseSelection<TOption>
-        where TBuilder : BaseSelectionBuilder<TSelection, TOption, TBuilder>
+    public abstract class BaseSelectionBuilderProperties<TOption> : IInteractiveBuilderProperties<TOption>
     {
         /// <summary>
         /// Gets whether the selection is restricted to <see cref="Users"/>.
@@ -64,7 +60,7 @@ namespace Fergun.Interactive.Selection
         /// <summary>
         /// Gets or sets the users who can interact with the <see cref="BaseSelection{TOption}"/>.
         /// </summary>
-        public virtual IList<IUser> Users { get; set; } = new List<IUser>();
+        public virtual ICollection<IUser> Users { get; set; } = new List<IUser>();
 
         /// <summary>
         /// Gets or sets the options to select from.
@@ -99,15 +95,23 @@ namespace Fergun.Interactive.Selection
         /// Gets or sets the action that will be done after valid input is received (except cancellation inputs).
         /// </summary>
         public virtual ActionOnStop ActionOnSuccess { get; set; }
+    }
 
-        /// <inheritdoc/>
-        ICollection<IUser> IInteractiveBuilder<TSelection, TOption, TBuilder>.Users
-        {
-            get => Users;
-            set => Users = value?.ToList() ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <inheritdoc />
+    /// <summary>
+    /// Represents the base of the selection builders.
+    /// </summary>
+    /// <typeparam name="TSelection">The type of the built selection.</typeparam>
+    /// <typeparam name="TOption">The type of the options the selection will have.</typeparam>
+    /// <typeparam name="TBuilder">The type of this builder.</typeparam>
+    public abstract class BaseSelectionBuilder<TSelection, TOption, TBuilder>
+        : BaseSelectionBuilderProperties<TOption>, IInteractiveBuilderMethods<TSelection, TOption, TBuilder>
+        where TSelection : BaseSelection<TOption>
+        where TBuilder : BaseSelectionBuilder<TSelection, TOption, TBuilder>
+    {
+        /// <summary>
+        /// Builds this <typeparamref name="TBuilder"/> into an immutable <typeparamref name="TSelection"/>.
+        /// </summary>
+        /// <returns>A <typeparamref name="TSelection"/>.</returns>
         public abstract TSelection Build();
 
         /// <summary>
@@ -117,7 +121,7 @@ namespace Fergun.Interactive.Selection
         /// Requirements for each input type:<br/><br/>
         /// Reactions: Required.<br/>
         /// Messages: Unused.<br/>
-        /// Buttons: Required (for emotes) unless a <see cref="StringConverter"/> is provided (for labels).<br/>
+        /// Buttons: Required (for emotes) unless a <see cref="BaseSelectionBuilderProperties{TOption}.StringConverter"/> is provided (for labels).<br/>
         /// Select menus: Optional.
         /// </remarks>
         public virtual TBuilder WithEmoteConverter(Func<TOption, IEmote> emoteConverter)
@@ -133,7 +137,7 @@ namespace Fergun.Interactive.Selection
         /// Requirements for each input type:<br/><br/>
         /// Reactions: Unused.<br/>
         /// Messages: Required. If not set, defaults to <see cref="object.ToString()"/>.<br/>
-        /// Buttons: Required (for labels) unless a <see cref="EmoteConverter"/> is provided (for emotes). Defaults to <see cref="object.ToString()"/> if neither are set.<br/>
+        /// Buttons: Required (for labels) unless a <see cref="BaseSelectionBuilderProperties{TOption}.EmoteConverter"/> is provided (for emotes). Defaults to <see cref="object.ToString()"/> if neither are set.<br/>
         /// Select menus: Required. If not set, defaults to <see cref="object.ToString()"/>.
         /// </remarks>
         public virtual TBuilder WithStringConverter(Func<TOption, string>? stringConverter)
@@ -155,7 +159,7 @@ namespace Fergun.Interactive.Selection
         /// <summary>
         /// Sets whether the <see cref="BaseSelection{TOption}"/> allows for cancellation.
         /// </summary>
-        /// <remarks>When this value is <see langword="true"/>, the last element in <see cref="Options"/>
+        /// <remarks>When this value is <see langword="true"/>, the last element in <see cref="BaseSelectionBuilderProperties{TOption}.Options"/>
         /// will be used to cancel the <see cref="BaseSelection{TOption}"/>.</remarks>
         /// <returns>This builder.</returns>
         public virtual TBuilder WithAllowCancel(bool allowCancel)

--- a/src/Selection/EmoteSelectionBuilder.cs
+++ b/src/Selection/EmoteSelectionBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Discord;
 
 namespace Fergun.Interactive.Selection
@@ -20,23 +19,17 @@ namespace Fergun.Interactive.Selection
         public override IEqualityComparer<KeyValuePair<IEmote, TValue>> EqualityComparer { get; set; } = new EmoteComparer<TValue>();
 
         /// <summary>
-        /// Gets or sets the options.
-        /// </summary>
-        public new IDictionary<IEmote, TValue> Options { get; set; } = new Dictionary<IEmote, TValue>();
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="EmoteSelectionBuilder{TValue}"/> class.
         /// </summary>
         public EmoteSelectionBuilder()
         {
         }
 
-        /// <inheritdoc/>
-        public override Selection<KeyValuePair<IEmote, TValue>> Build()
-            => new(EmoteConverter, StringConverter,
-                EqualityComparer, AllowCancel, SelectionPage.Build(), Users.ToArray(), Options.ToArray(),
-                CanceledPage?.Build(), TimeoutPage?.Build(), SuccessPage?.Build(), Deletion, InputType,
-                ActionOnCancellation, ActionOnTimeout, ActionOnSuccess);
+        /// <summary>
+        /// Builds this <see cref="EmoteSelectionBuilder{TValue}"/> into an immutable <see cref="Selection{TOption}"/>.
+        /// </summary>
+        /// <returns>A <see cref="Selection{TOption}"/>.</returns>
+        public override Selection<KeyValuePair<IEmote, TValue>> Build() => new(this);
 
         /// <summary>
         /// Sets the options.
@@ -57,7 +50,7 @@ namespace Fergun.Interactive.Selection
         /// <returns>This builder.</returns>
         public EmoteSelectionBuilder<TValue> AddOption(IEmote emote, TValue value)
         {
-            Options.Add(emote, value);
+            Options.Add(new KeyValuePair<IEmote, TValue>(emote, value));
             return this;
         }
     }
@@ -81,12 +74,11 @@ namespace Fergun.Interactive.Selection
         {
         }
 
-        /// <inheritdoc/>
-        public override Selection<IEmote> Build()
-            => new(EmoteConverter, StringConverter,
-                EqualityComparer, AllowCancel, SelectionPage?.Build()!, Users.ToArray(), Options.ToArray(),
-                CanceledPage?.Build(), TimeoutPage?.Build(), SuccessPage?.Build(), Deletion, InputType,
-                ActionOnCancellation, ActionOnTimeout, ActionOnSuccess);
+        /// <summary>
+        /// Builds this <see cref="EmoteSelectionBuilder"/> into an immutable <see cref="Selection{TOption}"/>.
+        /// </summary>
+        /// <returns>A <see cref="Selection{TOption}"/>.</returns>
+        public override Selection<IEmote> Build() => new(this);
     }
 
     internal class EmoteComparer<TValue> : IEqualityComparer<KeyValuePair<IEmote, TValue>>

--- a/src/Selection/Selection.cs
+++ b/src/Selection/Selection.cs
@@ -1,23 +1,13 @@
-using System;
-using System.Collections.Generic;
-using Discord;
-
 namespace Fergun.Interactive.Selection
 {
     /// <summary>
-    /// Represents a selection of values.
+    /// Represents a selection of options.
     /// </summary>
     /// <typeparam name="TOption">The type of the options.</typeparam>
     public class Selection<TOption> : BaseSelection<TOption>
     {
-        internal Selection(Func<TOption, IEmote>? emoteConverter, Func<TOption, string>? stringConverter,
-            IEqualityComparer<TOption> equalityComparer, bool allowCancel, Page selectionPage,
-            IReadOnlyCollection<IUser> users, IReadOnlyCollection<TOption> options, Page? canceledPage,
-            Page? timeoutPage, Page? successPage, DeletionOptions deletion, InputType inputType,
-            ActionOnStop actionOnCancellation, ActionOnStop actionOnTimeout, ActionOnStop actionOnSuccess)
-            : base(emoteConverter, stringConverter, equalityComparer, allowCancel, selectionPage, users, options,
-                canceledPage, timeoutPage, successPage, deletion, inputType, actionOnCancellation, actionOnTimeout,
-                actionOnSuccess)
+        internal Selection(BaseSelectionBuilderProperties<TOption> builder)
+            : base(builder)
         {
         }
     }

--- a/src/Selection/SelectionBuilder.cs
+++ b/src/Selection/SelectionBuilder.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace Fergun.Interactive.Selection
 {
     /// <summary>
@@ -16,12 +14,9 @@ namespace Fergun.Interactive.Selection
         }
 
         /// <summary>
-        /// Builds this builder into an immutable selection.
+        /// Builds this <see cref="SelectionBuilder{TOption}"/> into an immutable <see cref="Selection{TOption}"/>.
         /// </summary>
         /// <returns>A <see cref="Selection{TOption}"/>.</returns>
-        public override Selection<TOption> Build() => new(EmoteConverter, StringConverter,
-            EqualityComparer, AllowCancel, SelectionPage?.Build()!, Users.ToArray(), Options.ToArray(),
-            CanceledPage?.Build(), TimeoutPage?.Build(), SuccessPage?.Build(), Deletion, InputType,
-            ActionOnCancellation, ActionOnTimeout, ActionOnSuccess);
+        public override Selection<TOption> Build() => new(this);
     }
 }


### PR DESCRIPTION
This PR replaces the current constructors in paginators/selections with constructors with a single parameter. This parameter contains all the properties of their related builder that are required to build an immutable paginator/selection.

## Additions

- New interface `IInteractiveBuilderProperties`. It contains the properties of an `IInteractiveBuilder`.
- New interface `IInteractiveBuilderMethods`. It provides a fluent interface for `IInteractiveBuilder`.
- New class `PaginatorBuilderProperties`. It contains the properties of a `PaginatorBuilder`.
- New class `BaseSelectionBuilderProperties`. It contains the properties of a `BaseSelectionBuilder`.

## Changes

- Split `IInteractiveBuilder` into `IInteractiveBuilderProperties` and `IInteractiveBuilderMethods`.
- Moved the properties of `PaginatorBuilder` to `PaginatorBuilderProperties`.
- Moved the properties of `BaseSelectionBuilder` to `BaseSelectionBuilderProperties`.
- Modified the constructors of `Paginator` and `BaseSelection` to use `PaginatorBuilderProperties` and `BaseSelectionBuilderProperties` instead.
- Changed the type of `PaginatorBuilder.Users` and `BaseSelectionBuilder.Users` to `ICollection<T>`
- Moved the `startPageIndex` parameter in `PaginatoBuilder.Build()` to a separate property.