### PR TITLE
Add support for attachments in paginators and selections

### DIFF
--- a/ExampleBot/ExampleBot.csproj
+++ b/ExampleBot/ExampleBot.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Discord.Net.Commands" Version="3.5.0" />
+    <PackageReference Include="Discord.Net.Commands" Version="3.7.2" />
     <PackageReference Include="GScraper" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/ExampleBot/Modules/CustomPaginatorModule.cs
+++ b/ExampleBot/Modules/CustomPaginatorModule.cs
@@ -242,6 +242,7 @@ public class PagedSelection<TOption> : BaseSelection<KeyValuePair<TOption, Pagin
         }
 
         var currentPage = await paginator.GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+        var attachments = currentPage.AttachmentsFactory is null ? null : await currentPage.AttachmentsFactory().ConfigureAwait(false);
 
         await input.UpdateAsync(x =>
         {
@@ -249,6 +250,7 @@ public class PagedSelection<TOption> : BaseSelection<KeyValuePair<TOption, Pagin
             x.Embeds = currentPage.GetEmbedArray();
             x.Components = GetOrAddComponents(false).Build();
             x.AllowedMentions = currentPage.AllowedMentions;
+            x.Attachments = attachments is null ? new Optional<IEnumerable<FileAttachment>>() : new Optional<IEnumerable<FileAttachment>>(attachments);
         }).ConfigureAwait(false);
 
         return InteractiveInputStatus.Ignored;

--- a/src/Entities/Page/IPage.cs
+++ b/src/Entities/Page/IPage.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Discord;
 
 namespace Fergun.Interactive;
@@ -38,6 +40,11 @@ public interface IPage<out TEmbed> where TEmbed : IEmbed
     /// Gets the embeds of this page.
     /// </summary>
     IReadOnlyCollection<TEmbed> Embeds { get; }
+
+    /// <summary>
+    /// Gets the factory of attachments.
+    /// </summary>
+    Func<ValueTask<IEnumerable<FileAttachment>?>>? AttachmentsFactory { get; }
 }
 
 /// <inheritdoc/>

--- a/src/Entities/Page/MultiEmbedPageBuilder.cs
+++ b/src/Entities/Page/MultiEmbedPageBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Discord;
 
 namespace Fergun.Interactive;
@@ -48,6 +49,11 @@ public class MultiEmbedPageBuilder : IPageBuilder<MultiEmbedPage>, IPageBuilder
     /// </summary>
     /// <returns>The list of builders.</returns>
     public IList<EmbedBuilder> Builders { get; set; } = new List<EmbedBuilder>();
+
+    /// <summary>
+    /// Gets or sets the factory of attachments.
+    /// </summary>
+    public Func<ValueTask<IEnumerable<FileAttachment>?>>? AttachmentsFactory { get; set; }
 
     /// <summary>
     /// Builds this builder into a <see cref="MultiEmbedPage"/>.
@@ -180,6 +186,62 @@ public class MultiEmbedPageBuilder : IPageBuilder<MultiEmbedPage>, IPageBuilder
     {
         InteractiveGuards.NotNull(stickers);
         Stickers = stickers;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the function that generates the attachment.
+    /// </summary>
+    /// <remarks>To leave the attachment in the message unmodified, <paramref name="attachmentFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</remarks>
+    /// <param name="attachmentFactory">The attachment factory. To leave the attachment in the message unmodified, <paramref name="attachmentFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</param>
+    /// <returns>The current builder.</returns>
+    public MultiEmbedPageBuilder WithAttachmentFactory(Func<FileAttachment?> attachmentFactory)
+    {
+        InteractiveGuards.NotNull(attachmentFactory);
+        return WithAttachmentsFactory(() =>
+        {
+            var attachment = attachmentFactory();
+            return new ValueTask<IEnumerable<FileAttachment>?>(attachment is null ? null : new[] { attachment.Value });
+        });
+    }
+
+    /// <summary>
+    /// Sets the function that generates the attachment.
+    /// </summary>
+    /// <remarks>To leave the attachment in the message unmodified, <paramref name="attachmentFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</remarks>
+    /// <param name="attachmentFactory">The attachment factory. To leave the attachment in the message unmodified, <paramref name="attachmentFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</param>
+    /// <returns>The current builder.</returns>
+    public MultiEmbedPageBuilder WithAttachmentFactory(Func<ValueTask<FileAttachment?>> attachmentFactory)
+    {
+        InteractiveGuards.NotNull(attachmentFactory);
+        return WithAttachmentsFactory(async () =>
+        {
+            var attachment = await attachmentFactory().ConfigureAwait(false);
+            return attachment is null ? null : new[] { attachment.Value };
+        });
+    }
+
+    /// <summary>
+    /// Sets the function that generates the attachments.
+    /// </summary>
+    /// <remarks>To leave the attachments in the message unmodified, <paramref name="attachmentsFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</remarks>
+    /// <param name="attachmentsFactory">The attachments factory. To leave the attachments in the message unmodified, <paramref name="attachmentsFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</param>
+    /// <returns>The current builder.</returns>
+    public MultiEmbedPageBuilder WithAttachmentsFactory(Func<IEnumerable<FileAttachment>?> attachmentsFactory)
+    {
+        InteractiveGuards.NotNull(attachmentsFactory);
+        return WithAttachmentsFactory(() => new ValueTask<IEnumerable<FileAttachment>?>(attachmentsFactory()));
+    }
+
+    /// <summary>
+    /// Sets the function that generates the attachments.
+    /// </summary>
+    /// <remarks>To leave the attachments in the message unmodified, <paramref name="attachmentsFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</remarks>
+    /// <param name="attachmentsFactory">The attachments factory. To leave the attachments in the message unmodified, <paramref name="attachmentsFactory"/> must return <see langword="null"/> instead of a <see cref="FileAttachment"/> object.</param>
+    /// <returns>The current builder.</returns>
+    public MultiEmbedPageBuilder WithAttachmentsFactory(Func<ValueTask<IEnumerable<FileAttachment>?>>? attachmentsFactory)
+    {
+        AttachmentsFactory = attachmentsFactory;
         return this;
     }
 

--- a/src/Entities/Page/Page.cs
+++ b/src/Entities/Page/Page.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Discord;
 
 namespace Fergun.Interactive;
@@ -21,6 +22,7 @@ public class Page : IPage
         AllowedMentions = page.AllowedMentions;
         MessageReference = page.MessageReference;
         Stickers = page.Stickers;
+        AttachmentsFactory = page.AttachmentsFactory;
 
         bool isEmpty = false;
         var builder = page._builder;
@@ -36,9 +38,9 @@ public class Page : IPage
             builder?.Title is null &&
             builder?.Url is null)
         {
-            if (string.IsNullOrEmpty(page.Text))
+            if (string.IsNullOrEmpty(page.Text) && AttachmentsFactory is null)
             {
-                throw new InvalidOperationException("Either a text or a valid EmbedBuilder must be present.");
+                throw new InvalidOperationException("Either a text, a valid EmbedBuilder or an AttachmentsFactory must be present.");
             }
 
             isEmpty = true;
@@ -62,6 +64,9 @@ public class Page : IPage
 
     /// <inheritdoc/>
     public IReadOnlyCollection<ISticker> Stickers { get; }
+
+    /// <inheritdoc/>
+    public Func<ValueTask<IEnumerable<FileAttachment>?>>? AttachmentsFactory { get; }
 
     /// <summary>
     /// Gets the embed of this page.

--- a/src/Fergun.Interactive.csproj
+++ b/src/Fergun.Interactive.csproj
@@ -22,7 +22,7 @@ This is a fork of Discord.InteractivityAddon that adds several features like mor
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.WebSocket" Version="3.5.0" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="3.7.2" />
     <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -449,11 +449,14 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
         if (action == PaginatorAction.Jump && await JumpToPageAsync(input).ConfigureAwait(false))
         {
             var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+            var attachments = currentPage.AttachmentsFactory is null ? null : await currentPage.AttachmentsFactory().ConfigureAwait(false);
+
             await message.ModifyAsync(x =>
             {
                 x.Embeds = currentPage.GetEmbedArray();
                 x.Content = currentPage.Text;
                 x.AllowedMentions = currentPage.AllowedMentions;
+                x.Attachments = attachments is null ? new Optional<IEnumerable<FileAttachment>>() : new Optional<IEnumerable<FileAttachment>>(attachments);
             }).ConfigureAwait(false);
         }
 
@@ -461,11 +464,14 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
         if (refreshPage)
         {
             var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+            var attachments = currentPage.AttachmentsFactory is null ? null : await currentPage.AttachmentsFactory().ConfigureAwait(false);
+
             await message.ModifyAsync(x =>
             {
                 x.Embeds = currentPage.GetEmbedArray();
                 x.Content = currentPage.Text;
                 x.AllowedMentions = currentPage.AllowedMentions;
+                x.Attachments = attachments is null ? new Optional<IEnumerable<FileAttachment>>() : new Optional<IEnumerable<FileAttachment>>(attachments);
             }).ConfigureAwait(false);
         }
 
@@ -508,6 +514,7 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
         if (action == PaginatorAction.Jump && await JumpToPageAsync(input).ConfigureAwait(false))
         {
             var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+            var attachments = currentPage.AttachmentsFactory is null ? null : await currentPage.AttachmentsFactory().ConfigureAwait(false);
             var buttons = GetOrAddComponents(false).Build();
 
             await input.ModifyOriginalResponseAsync(x =>
@@ -516,6 +523,7 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
                 x.Embeds = currentPage.GetEmbedArray();
                 x.Components = buttons;
                 x.AllowedMentions = currentPage.AllowedMentions;
+                x.Attachments = attachments is null ? new Optional<IEnumerable<FileAttachment>>() : new Optional<IEnumerable<FileAttachment>>(attachments);
             }).ConfigureAwait(false);
         }
 
@@ -523,6 +531,7 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
         if (refreshPage)
         {
             var currentPage = await GetOrLoadCurrentPageAsync().ConfigureAwait(false);
+            var attachments = currentPage.AttachmentsFactory is null ? null : await currentPage.AttachmentsFactory().ConfigureAwait(false);
             var buttons = GetOrAddComponents(false).Build();
 
             await input.UpdateAsync(x =>
@@ -531,6 +540,7 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
                 x.Embeds = currentPage.GetEmbedArray();
                 x.Components = buttons;
                 x.AllowedMentions = currentPage.AllowedMentions;
+                x.Attachments = attachments is null ? new Optional<IEnumerable<FileAttachment>>() : new Optional<IEnumerable<FileAttachment>>(attachments);
             }).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
This PR adds support for attachments in paginators and selections via a new property: `AttachmentsFactory`.

This property of type `Func<ValueTask<IEnumerable<FileAttachment>?>>?` is used to generate an `IEnumerable<FileAttachment>`. A delegate is used so the `FileAttachment`s can be created on demand and avoid reusing the streams they contain.

Note: This PR will be on hold because currently Discord.Net doesn't support attachments on interaction respond type 7 (UpdateAsync). A [PR](https://github.com/discord-net/Discord.Net/pull/2336) has been made to fix this and this PR will be merged after the other is merged.