### PR TITLE
Add `UseInteractiveService` extension method for `IHostBuilder` to simplify hosting.

### DIFF
--- a/src/Extensions/HostBuilderExtensions.cs
+++ b/src/Extensions/HostBuilderExtensions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+
+namespace Fergun.Interactive.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="IHostBuilder"/>.
+/// </summary>
+public static class HostBuilderExtensions
+{
+    /// <summary>
+    /// Adds <see cref="InteractiveService"/> and optionally configures a <see cref="InteractiveConfig"/> along with the required services.
+    /// </summary>
+    /// <param name="builder">The host builder to configure.</param>
+    /// <param name="config">The delegate for the <see cref="InteractiveConfig" /> that will be used to configure the host.</param>
+    /// <returns>The generic host builder.</returns>
+    public static IHostBuilder UseInteractiveService(this IHostBuilder builder, Action<HostBuilderContext, InteractiveConfig>? config = null)
+    {
+        return builder.ConfigureServices((context, collection) =>
+        {
+            if (config != null)
+                collection.AddSingleton(config);
+
+            collection.AddSingleton<InteractiveService>();
+        });
+    }
+}

--- a/src/Fergun.Interactive.csproj
+++ b/src/Fergun.Interactive.csproj
@@ -23,6 +23,7 @@ This is a fork of Discord.InteractivityAddon that adds several features like mor
 
   <ItemGroup>
     <PackageReference Include="Discord.Net.WebSocket" Version="3.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="PolySharp" Version="1.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
# Changes
- Added simple extension method to simplify configuration via `IHostBuilder` using [Discord.Addons.Hosting](https://github.com/Hawxy/Discord.Addons.Hosting);

## Pros
- This may be very useful and simple to configure with [Discord.Addons.Hosting](https://github.com/Hawxy/Discord.Addons.Hosting);

## Usage example
```cs
host.UseInteractiveService((context, config) =>
{
    config.LogLevel = LogSeverity.Critical;
    config.DeferStopSelectionInteractions = true;
    config.DefaultTimeout = TimeSpan.FromMinutes(5);
})
```

The code above basicly do two things:
- Add the `InteractiveService` to the host services collection;
- Optionally configures `InteractiveConfig` along with the required services;

### Conclusion
This way, configuration will become very simple and clear.