### PR TITLE
Paginator refactoring

### DIFF
--- a/src/Entities/Page/PageBuilder.cs
+++ b/src/Entities/Page/PageBuilder.cs
@@ -348,7 +348,7 @@ public class PageBuilder : IPageBuilder<Page>, IPageBuilder
     public PageBuilder WithAuthor(IUser user)
     {
         InteractiveGuards.NotNull(user);
-        return WithAuthor(user.ToString(), user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl());
+        return WithAuthor(user.ToString(), user.GetDisplayAvatarUrl());
     }
 
     /// <summary>

--- a/src/Pagination/Paginator.cs
+++ b/src/Pagination/Paginator.cs
@@ -518,12 +518,10 @@ public abstract class Paginator : IInteractiveElement<KeyValuePair<IEmote, Pagin
         if (!Enum.IsDefined(typeof(PaginatorAction), action))
         {
             // Obsolete way to get the PaginatorAction for backward compatibility.
-            var emote = (input
-                    .Message
-                    .Components
-                    .SelectMany(x => x.Components)
-                    .FirstOrDefault(x => x is ButtonComponent button && button.CustomId == input.Data.CustomId) as ButtonComponent)?
-                .Emote;
+            IEmote? emote = input.Message.Components
+                .SelectMany(row => row.Components.OfType<ButtonComponent>())
+                .SingleOrDefault(button => button.CustomId == input.Data.CustomId)
+                ?.Emote;
 
             if (emote is null || !Emotes.TryGetValue(emote, out action))
                 return InteractiveInputStatus.Ignored;

--- a/src/Pagination/PaginatorBuilder.cs
+++ b/src/Pagination/PaginatorBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Discord;
 

--- a/src/Pagination/PaginatorBuilder.cs
+++ b/src/Pagination/PaginatorBuilder.cs
@@ -38,7 +38,7 @@ public abstract class PaginatorBuilder<TPaginator, TBuilder>
     /// <summary>
     /// Gets or sets the users who can interact with the paginator.
     /// </summary>
-    public virtual ICollection<IUser> Users { get; set; } = new Collection<IUser>();
+    public virtual ICollection<IUser> Users { get; set; } = [];
 
     /// <inheritdoc/>
     public virtual IDictionary<IEmote, PaginatorAction> Options

--- a/src/Selection/BaseSelectionBuilder.cs
+++ b/src/Selection/BaseSelectionBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Discord;
 

--- a/src/Selection/BaseSelectionBuilder.cs
+++ b/src/Selection/BaseSelectionBuilder.cs
@@ -36,12 +36,12 @@ public abstract class BaseSelectionBuilder<TSelection, TOption, TBuilder>
     public virtual IPageBuilder SelectionPage { get; set; } = null!;
 
     /// <inheritdoc/>
-    public virtual ICollection<IUser> Users { get; set; } = new Collection<IUser>();
+    public virtual ICollection<IUser> Users { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the options to select from.
     /// </summary>
-    public virtual ICollection<TOption> Options { get; set; } = new Collection<TOption>();
+    public virtual ICollection<TOption> Options { get; set; } = [];
 
     /// <inheritdoc />
     public virtual IPageBuilder? CanceledPage { get; set; }


### PR DESCRIPTION
This pull request includes some fixes and brings several improvements to the `Paginator` class, enhancing the code readability.

Previously, the logic for navigating to different pages (next, previous, first, and last) was hardcoded within the `ApplyActionAsync` method. We have now extracted this logic into four separate methods: `SetNextPageAsync`, `SetPreviousPageAsync`, `SetFirstPageAsync`, and `SetLastPageAsync`. Each method is responsible for a specific navigation action, adhering to the Single Responsibility Principle.